### PR TITLE
Fix running unit tests with setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+python:
+  - 3.6
+
 install:
   - python setup.py install
 


### PR DESCRIPTION
This fixes running the tests with `python3 setup.py test`, and I think it fixes Travis stuff at the same time.