### PR TITLE
Changed semantics of `util.files_modified_by_commit`

### DIFF
--- a/src/blameandshame/util.py
+++ b/src/blameandshame/util.py
@@ -64,7 +64,9 @@ def files_modified_by_commit(repo: git.Repo,
     """
     fix_commit = repo.commit(fix_sha)
     prev_commit = repo.commit("{}~1".format(fix_sha))
-    return frozenset(fix_commit.stats.files.keys())
+    diff = prev_commit.diff(fix_commit)
+
+    return frozenset(d.a_path for d in diff.iter_change_type('M'))
 
 
 def lines_modified_by_commit(repo: git.Repo,

--- a/src/blameandshame/util.py
+++ b/src/blameandshame/util.py
@@ -66,7 +66,7 @@ class Change(Enum):
 
 def files_in_commit(repo: git.Repo,
                     fix_sha: str,
-                    filter_by: FrozenSet[Change] = frozenset(Change)
+                    filter_by: Set[Change] = {f for f in Change}
                    ) -> FrozenSet[str]:
     """
     Returns the set of files, given by name, that were modified by a given

--- a/src/blameandshame/util.py
+++ b/src/blameandshame/util.py
@@ -3,7 +3,7 @@ import shutil
 import os
 import git
 import urllib.parse
-from typing import FrozenSet, List, Tuple, Set
+from typing import FrozenSet, Tuple, Set
 
 
 DESC = "TODO: Add a description of how this tool works."

--- a/src/blameandshame/util.py
+++ b/src/blameandshame/util.py
@@ -56,11 +56,13 @@ def get_repo(repo_url: str) -> git.Repo:
 
     return git.Repo(path)
 
+
 class Change(Enum):
     ADDED = 'A'
     DELETED = 'D'
     MODIFIED = 'M'
     RENAMED = 'R'
+
 
 def files_in_commit(repo: git.Repo,
                     fix_sha: str,
@@ -79,6 +81,7 @@ def files_in_commit(repo: git.Repo,
         files.update(d.a_path for d in diff.iter_change_type(f.value))
 
     return frozenset(files)
+
 
 def lines_modified_by_commit(repo: git.Repo,
                              fix_sha: str) -> Tuple[FrozenSet[Tuple[str, int]],

--- a/src/blameandshame/util.py
+++ b/src/blameandshame/util.py
@@ -58,6 +58,10 @@ def get_repo(repo_url: str) -> git.Repo:
 
 
 class Change(Enum):
+    """
+    Enum of the possible types of git changes. These values can be used as
+    arguments to the Diff object's iter_change_type method.
+    """
     ADDED = 'A'
     DELETED = 'D'
     MODIFIED = 'M'

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -37,8 +37,9 @@ class UtilTestCase(unittest.TestCase):
                                     'ruby/Rakefile',
                                     'Makefile.am',
                                     '.gitignore',
-                                    'ruby/ext/google/protobuf_c/protobuf.h',
-                                    'ruby/tests/gc_test.rb']))
+                                    'ruby/ext/google/protobuf_c/protobuf.h']))
+        # note: `ruby/tests/gc_test.rb` is added and thus should not be
+        #       considered as 'modified'.
 
 
     def test_lines_modified_by_commit(self):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import os
 import unittest
-from blameandshame.util import  repo_path, \
-                                files_modified_by_commit, \
-                                lines_modified_by_commit, \
-                                get_repo
+from blameandshame.util import Change
+from blameandshame.util import repo_path, \
+                               files_in_commit, \
+                               lines_modified_by_commit, \
+                               get_repo
 
 
 class UtilTestCase(unittest.TestCase):
@@ -24,13 +25,13 @@ class UtilTestCase(unittest.TestCase):
                          os.path.join(repos_dir, 'opencv'))
 
 
-    def test_files_modified_by_commit(self):
+    def test_files_in_commit(self):
         repo = get_repo('https://github.com/google/protobuf')
-        self.assertEqual(files_modified_by_commit(repo, 'baed06e'),
+        self.assertEqual(files_in_commit(repo, 'baed06e'),
                          frozenset(['objectivec/GPBCodedOutputStream.m']))
-        self.assertEqual(files_modified_by_commit(repo, '949596e'),
+        self.assertEqual(files_in_commit(repo, '949596e'),
                          frozenset(['objectivec/GPBMessage.m']))
-        self.assertEqual(files_modified_by_commit(repo, 'cd5f49d'),
+        self.assertEqual(files_in_commit(repo, 'cd5f49d', {Change.MODIFIED}),
                          frozenset(['ruby/travis-test.sh',
                                     'ruby/ext/google/protobuf_c/protobuf.c',
                                     'ruby/ext/google/protobuf_c/defs.c',
@@ -38,6 +39,17 @@ class UtilTestCase(unittest.TestCase):
                                     'Makefile.am',
                                     '.gitignore',
                                     'ruby/ext/google/protobuf_c/protobuf.h']))
+        self.assertEqual(files_in_commit(repo, 'cd5f49d', {Change.ADDED}),
+                         frozenset(['ruby/tests/gc_test.rb']))
+        self.assertEqual(files_in_commit(repo, 'cd5f49d'),
+                         frozenset(['ruby/travis-test.sh',
+                                    'ruby/ext/google/protobuf_c/protobuf.c',
+                                    'ruby/ext/google/protobuf_c/defs.c',
+                                    'ruby/Rakefile',
+                                    'Makefile.am',
+                                    '.gitignore',
+                                    'ruby/ext/google/protobuf_c/protobuf.h',
+                                    'ruby/tests/gc_test.rb']))
         # note: `ruby/tests/gc_test.rb` is added and thus should not be
         #       considered as 'modified'.
 


### PR DESCRIPTION
In its updated form, `files_modified_by_commit` does not consider files that were added by a commit to be *modified*.